### PR TITLE
Set Platform to iOS 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Fuzzi",
-    platforms: [.iOS(.v10), .macOS(.v10_15)],
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
         .library(name: "Fuzzi",
                  targets: ["Fuzzi"]),


### PR DESCRIPTION
Since `'some' return types are only available in iOS 13.0.0 or newer` I bumped the deployment target to iOS 13